### PR TITLE
Fixing a few links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repo is the home for content that embodies the processes and focus topics for the DIDComm User Group. Welcome! We'd love to collaborate with you. See [Contributing](contributing.md).
 
-* [Charter](charter)
-* [Schedule](schedule)
+* [Charter](charter.md)
+* [Schedule](schedule.md)
 * [Meeting archive](meetings)
 * [Discord channel](https://discord.gg/eNN4Wns6Jb)
 * [Mailing list](https://lists.identity.foundation/g/didcomm-usergroup)


### PR DESCRIPTION
The Charter and Schedule links on the README.md file returned in 404 errors.  I added the ".md" extensions.